### PR TITLE
fixed a single line causing a compile error on the Vulkan example

### DIFF
--- a/vulkan/setup_sdl2_debug.odin
+++ b/vulkan/setup_sdl2_debug.odin
@@ -787,7 +787,7 @@ main :: proc() {
 	for running {
 		// this is our event loop for input processing
 		event : sdl.Event
-		for sdl.PollEvent(&event) != 0 {
+		for sdl.PollEvent(&event) {
 			if event.type == .QUIT {
 				running = false
 			}


### PR DESCRIPTION
Before the fix, attempting to compile the Vulkan example resulted in the following error:
```
C:/.../vulkan/setup_sdl2_debug.odin(790:32) Error: Cannot convert '0' to 'b32' from 'untyped integer', got 0
        for sdl.PollEvent(&event) != 0 {
                                     ^
```
After removing the `!= 0` section of this line, the program compiled.